### PR TITLE
typo reverse blue/red keys in example

### DIFF
--- a/examples/04_marked_scale.p6
+++ b/examples/04_marked_scale.p6
@@ -1,14 +1,13 @@
 #!/usr/bin/env perl6
 
 use v6;
-use lib 'lib';
 use GTK::Simple;
 
 my GTK::Simple::App $app .=new( :title( 'More widgets') );
 =comment
     We introduce the MarkUpLabel and Scale widgets
 
-my %texts = <red blue> Z=>
+my %texts = <blue red> Z=>
     '<span foreground="blue" size="x-large">Blue text</span> is <i>cool</i>!',
     '<span foreground="red" size="x-large">Red text</span> is <b>hot</b>!'
 ;


### PR DESCRIPTION
Error in example due to reverse keys in hash definition.
