### PR TITLE
get-active method to combobox

### DIFF
--- a/examples/06-combo.pl6
+++ b/examples/06-combo.pl6
@@ -25,19 +25,22 @@ $combo.changed.tap({
 =comment preset the active item.
 
 my $pre-set-combo = GTK::Simple::ComboBoxText.new();
-my @items = <zero one two three four five six>;
+my @items = <alpha beta gamma delta epsilon zeta eta theta>;
 
 for @items -> $item {
     $pre-set-combo.append-text( $item )
 }
 
-$pre-set-combo.set-active( 3 );
+my $index = 4;
+$pre-set-combo.set-active( $index );
 =comment
     If the index is 0 > index > @item.end then nothing happens.
 
-my $lbl2 = GTK::Simple::Label.new( text => @items[3] );
+my $lbl2 = GTK::Simple::Label.new( text => @items[$index] );
 
-$pre-set-combo.changed.tap: { $lbl2.text = $pre-set-combo.active-text();  };
+$pre-set-combo.changed.tap: { 
+    $lbl2.text = 'ComboBoxText has selection ' ~ $pre-set-combo.active-text() ~ ', which has index ' ~ $pre-set-combo.get-active(); 
+};
 
 
 $app.set-content(GTK::Simple::VBox.new($label, $combo, $lbl2, $pre-set-combo));

--- a/lib/GTK/Simple/ComboBoxText.pm6
+++ b/lib/GTK/Simple/ComboBoxText.pm6
@@ -49,6 +49,10 @@ method set-active( $index ) {
     gtk_combo_box_set_active($!gtk_widget,$index)
 }
 
+method get-active() returns Int {
+    gtk_combo_box_get_active($!gtk_widget)
+}
+
 has $!changed_supply;
 method changed() {
     $!changed_supply //= do {

--- a/lib/GTK/Simple/Raw.pm6
+++ b/lib/GTK/Simple/Raw.pm6
@@ -290,6 +290,12 @@ sub gtk_combo_box_set_active(GtkWidget $widget, int32 $index)
     is export(:combo-box-text)
     { * }
 
+sub gtk_combo_box_get_active(GtkWidget $widget)
+    is native(&gtk-lib)
+    is export(:combo-box-text)
+    returns int32
+    { * }
+
 sub gtk_combo_box_text_get_active_text(GtkWidget $widget)
     is native(&gtk-lib)
     is export(:combo-box-text)


### PR DESCRIPTION
This complements the set-active method.
Changed example 6 to demonstrate use of method
