### PR TITLE
Fix DLL bundling by using %?RESOURCES

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -30,7 +30,8 @@ class Build is Panda::Builder {
                 $out.lines.grep({$_.chars})[*-1];
             }
             say 'No system gtk library detected. Installing bundled version.';
-            mkdir($workdir ~ '\blib\lib\GTK');
+            my $basedir = $workdir ~ '\resources\blib\lib\GTK';
+            mkdir($basedir);
             my @files = ("libatk-1.0-0.dll",
                          "libcairo-2.dll",
                          "libcairo-gobject-2.dll",
@@ -83,10 +84,10 @@ class Build is Panda::Builder {
                 say "Fetching  " ~ $f;
                 my $blob = LWP::Simple.get('http://gtk-dlls.p6c.org/' ~ $f);
                 say "Writing   " ~ $f;
-                spurt($workdir ~ '\blib\lib\GTK\\' ~ $f, $blob);
+                spurt("$basedir\\" ~ $f, $blob);
 
                 say "Verifying " ~ $f;
-                my $hash = ps-hash($workdir ~ '\blib\lib\GTK\\' ~ $f);
+                my $hash = ps-hash("$basedir\\" ~ $f);
                 if ($hash ne $h) {
                     die "Bad download of $f (got: $hash; expected: $h)";
                 }

--- a/Build.pm
+++ b/Build.pm
@@ -81,13 +81,13 @@ class Build is Panda::Builder {
                           "4F1032F0D7F6F0C2046A96884FD48EC0F7C0A1E22C85E9076057756C4C48E0CB",
                           "5A697F89758B407EE85BAD35376546A80520E1F3092D07F1BC366A490443FAB5");
             for flat @files Z @hashes -> $f, $h {
-                say "Fetching  " ~ $f;
-                my $blob = LWP::Simple.get('http://gtk-dlls.p6c.org/' ~ $f);
-                say "Writing   " ~ $f;
-                spurt("$basedir\\" ~ $f, $blob);
+                say "Fetching  $f";
+                my $blob = LWP::Simple.get("http://gtk-dlls.p6c.org/$f");
+                say "Writing   $f";
+                spurt("$basedir\\$f", $blob);
 
-                say "Verifying " ~ $f;
-                my $hash = ps-hash("$basedir\\" ~ $f);
+                say "Verifying $f";
+                my $hash = ps-hash("$basedir\\$f");
                 if ($hash ne $h) {
                     die "Bad download of $f (got: $hash; expected: $h)";
                 }

--- a/META6.json
+++ b/META6.json
@@ -50,5 +50,31 @@
         "GTK::Simple::Window"            : "lib/GTK/Simple/Window.pm6"
     },
     "repo-type" : "git",
-    "source-url" : "git://github.com/perl6/gtk-simple.git"
+    "source-url" : "git://github.com/perl6/gtk-simple.git",
+    "resources" : [
+        "blib/lib/GTK/libatk-1.0-0.dll",
+        "blib/lib/GTK/libcairo-2.dll",
+        "blib/lib/GTK/libcairo-gobject-2.dll",
+        "blib/lib/GTK/libffi-6.dll",
+        "blib/lib/GTK/libfontconfig-1.dll",
+        "blib/lib/GTK/libfreetype-6.dll",
+        "blib/lib/GTK/libgdk-3-0.dll",
+        "blib/lib/GTK/libgdk_pixbuf-2.0-0.dll",
+        "blib/lib/GTK/libgio-2.0-0.dll",
+        "blib/lib/GTK/libglib-2.0-0.dll",
+        "blib/lib/GTK/libgmodule-2.0-0.dll",
+        "blib/lib/GTK/libgobject-2.0-0.dll",
+        "blib/lib/GTK/libgtk-3-0.dll",
+        "blib/lib/GTK/libiconv-2.dll",
+        "blib/lib/GTK/libintl-8.dll",
+        "blib/lib/GTK/liblzma-5.dll",
+        "blib/lib/GTK/libpango-1.0-0.dll",
+        "blib/lib/GTK/libpangocairo-1.0-0.dll",
+        "blib/lib/GTK/libpangoft2-1.0-0.dll",
+        "blib/lib/GTK/libpangowin32-1.0-0.dll",
+        "blib/lib/GTK/libpixman-1-0.dll",
+        "blib/lib/GTK/libpng15-15.dll",
+        "blib/lib/GTK/libxml2-2.dll",
+        "blib/lib/GTK/zlib1.dll"
+    ]
 }

--- a/lib/GTK/Simple/NativeLib.pm6
+++ b/lib/GTK/Simple/NativeLib.pm6
@@ -92,18 +92,11 @@ sub gobject-lib is export {
 
 sub find-bundled($lib is copy) {
     # if we can't find one, assume there's a system install
-    my $base = "lib/GTK/$lib";
-    for @*INC {
-        if my @files = ($_.files($base) || $_.files("blib/$base")) {
-            my $files = @files[0]<files>;
-            my $tmp = $files{$base} || $files{"blib/$base"};
+    my $base = "blib/lib/GTK/$lib";
 
-            # copy to a temp dir
-            $tmp.IO.copy($*SPEC.tmpdir ~ '\\' ~ $lib);
+    if my $file = %?RESOURCES{$base} {
+            $file.IO.copy($*SPEC.tmpdir ~ '\\' ~ $lib);
             $lib = $*SPEC.tmpdir ~ '\\' ~ $lib;
-
-            last;
-        }
     }
 
     $lib;


### PR DESCRIPTION
@*INC is not available in latest rakudo versions. This made GTK::Simple impossible to build/install/use on Windows. These changes utilize %?RESOURCES to enable GTK::Simple on Windows to work again.
