### PR TITLE
Trying to fix CI builds on mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install libgtk-3-dev ; fi
   - if [ "$TRAVIS_OS_NAME" == "osx"   ]; then brew update                       ; fi
   - if [ "$TRAVIS_OS_NAME" == "osx"   ]; then brew install gtk+3                ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx"   ]; then ulimit -n 8192                    ; fi
 
 install:
   - rakudobrew build panda


### PR DESCRIPTION
Travis CI builds for GTK::Simple failed because of `too many open files` : https://travis-ci.org/perl6/gtk-simple/jobs/139524909

This increases the limit of open files for OSX builds.
