### PR TITLE
ScrolledWindow widget & example + 01-example typos

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -47,7 +47,8 @@
         "GTK::Simple::Toolbar"           : "lib/GTK/Simple/Toolbar.pm6",
         "GTK::Simple::VBox"              : "lib/GTK/Simple/VBox.pm6",
         "GTK::Simple::Widget"            : "lib/GTK/Simple/Widget.pm6",
-        "GTK::Simple::Window"            : "lib/GTK/Simple/Window.pm6"
+        "GTK::Simple::Window"            : "lib/GTK/Simple/Window.pm6",
+        "GTK::Simple::ScrolledWindow"    : "lib/GTK/Simple/ScrolledWindow.pm6"
     },
     "repo-type" : "git",
     "source-url" : "git://github.com/perl6/gtk-simple.git",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ MenuItem          | A simple menu item that can have a sub menu
 MenuToolButton    | A menu tool button with a label or an icon
 PlacesSidebar     | Sidebar that displays frequently-used places in the file system
 Scale             | Allows for a number to be provided by the user
+ScrolledWindo     | Container for widgets needing scrolling, eg., multiline texts
 RadioButton       | A choice from multiple check buttons
 Spinner           | Showing that something is happening
 TextView          | Adds multiple lines of text

--- a/examples/01-hello-world.pl6
+++ b/examples/01-hello-world.pl6
@@ -17,7 +17,7 @@ my GTK::Simple::App $app .= new(title => "Hello GTK!");
     to put widgets into its body.
 
     In other GTK tutorials, you'll find that you have to C<gtk_widget_show>
-    all widgets as well as the window. set_content does all of that for us.
+    all widgets as well as the window. set-content does all of that for us.
 =end comment
 
 $app.set-content(
@@ -34,9 +34,9 @@ $app.set-content(
 
 
 =comment
-    Setting the C<border_width> of any C<GTK::Simple::Container> adds
+    Setting the C<border-width> of any C<GTK::Simple::Container> adds
     a B<border around the container>.
-    C<border_width> on a window, however, is special-cased to put
+    C<border-width> on a window, however, is special-cased to put
     a border U<inside> the window instead.
 
 $app.border-width = 20;

--- a/examples/17-scrolled-window-with-textview.p6
+++ b/examples/17-scrolled-window-with-textview.p6
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl6
+
+use v6.c;
+use lib 'lib';
+use GTK::Simple;
+
+my $app = GTK::Simple::App.new(title=> 'Example 17');
+my $send-history = GTK::Simple::TextView.new(text=>'Old stuff');
+my $flood-data = GTK::Simple::ToggleButton.new(label=>'Flood with stuff');
+my $exit-b = GTK::Simple::ToggleButton.new(label=>'Exit');
+
+my $scrolled = GTK::Simple::ScrolledWindow.new;
+
+=comment
+    ScrolledWindow is a container, so standard container commands work
+
+$scrolled.set-content( $send-history );
+
+my $v  = GTK::Simple::VBox.new( 
+    $flood-data,
+    $scrolled,
+    $exit-b
+);
+
+$flood-data.toggled.tap: -> $b { 
+    my $s = 'Twas brillig and the slithy toothes did gyre and gymbol';
+    for ^25 { $send-history.text ~= (' ' x $_) ~ "$s\n" }
+};
+$exit-b.toggled.tap(-> $b { $app.exit } );
+
+$app.set-content( $v );
+$app.border-width = 20;
+$app.run;

--- a/lib/GTK/Simple.pm6
+++ b/lib/GTK/Simple.pm6
@@ -38,3 +38,4 @@ require GTK::Simple::PlacesSidebar;
 require GTK::Simple::RadioButton;
 require GTK::Simple::LevelBar;
 require GTK::Simple::LinkButton;
+require GTK::Simple::ScrolledWindow;

--- a/lib/GTK/Simple/Raw.pm6
+++ b/lib/GTK/Simple/Raw.pm6
@@ -34,6 +34,18 @@ enum GtkLevelBarMode is export(:level-bar) (
     GTK_LEVEL_BAR_MODE_DISCRETE   => 1,
 );
 
+#Determines how the size should be computed to achieve the one of the visibility mode for the scrollbars.
+enum GtkPolicyType is export(:scrolled-window) (
+    GTK_POLICY_ALWAYS => 0,     #The scrollbar is always visible.
+                                #The view size is independent of the content.
+    GTK_POLICY_AUTOMATIC => 1,  #The scrollbar will appear and disappear as necessary.
+                                #For example, when all of a Gtk::TreeView can not be seen.
+    GTK_POLICY_NEVER => 2,      #The scrollbar should never appear.
+                                #In this mode the content determines the size.
+    GTK_POLICY_EXTERNAL => 3,   #Don't show a scrollbar, but don't force the size to follow the content.
+                                #This can be used e.g. to make multiple scrolled windows share a scrollbar.
+);
+
 # gtk_widget_... {{{
 
 sub gtk_widget_show(GtkWidget $widgetw)
@@ -954,7 +966,7 @@ sub gtk_level_bar_set_max_value(GtkWidget $level-bar, num64 $max-value)
     is export(:level-bar)
     { * }
 
-sub gtk_level_bar_get_min_value(GtkWidget $level-bar)
+sub gtk_level_bar_get_min_value(GtkWidget $GTK_POLICY_AUTOMATIClevel-bar)
     returns num64
     is native(&gtk-lib)
     is export(:level-bar)
@@ -986,3 +998,21 @@ sub gtk_level_bar_set_value(GtkWidget $level-bar, num64 $value)
     is native(&gtk-lib)
     is export(:level-bar)
     { * }
+#
+# Scrolled Window
+#
+sub gtk_scrolled_window_new()
+    returns GtkWidget
+    is native(&gtk-lib)
+    is export(:scrolled-window)
+    { * }
+    
+sub gtk_scrolled_window_set_policy(GtkWidget $scrolled_window, 
+                                  int32 $h-bar-policy, 
+                                  int32 $v-bar-policy)
+    is native(&gtk-lib)
+    is export(:scrolled-window)
+    { * }
+    
+                                   
+

--- a/lib/GTK/Simple/ScrolledWindow.pm6
+++ b/lib/GTK/Simple/ScrolledWindow.pm6
@@ -1,0 +1,17 @@
+
+use v6;
+
+use GTK::Simple::Raw :scrolled-window, :DEFAULT;
+use GTK::Simple::Widget;
+use GTK::Simple::Container;
+
+unit class GTK::Simple::ScrolledWindow
+    does GTK::Simple::Widget
+    does GTK::Simple::Container;
+
+submethod BUILD(Cool :$title = "Gtk Scrolled Window", 
+                GtkPolicyType :$hpolicy = GTK_POLICY_AUTOMATIC,
+                GtkPolicyType :$vpolity = GTK_POLICY_AUTOMATIC) {
+    $!gtk_widget = gtk_scrolled_window_new; # the null paramenters are for 'hadjust' structures, not normally needed
+    gtk_scrolled_window_set_policy($!gtk_widget, $hpolicy, $vpolity);
+}


### PR DESCRIPTION
ScrolledWindow widget works well. Defaults to automatic scrollbars. 

Example shows use of a TextView inside a scrolled window.

Minor edits:
'_' -> '-' changes were made in the sub names but not in the comments.

Also, some examples still have routine_names, rather than routine-names, but these are defined in the examples, so it's a matter of taste for the example writer, rather than a standarisation for the module. So I did'nt change these. 
