### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "name"          : "GTK::Simple",
+    "license"       : "Artistic-2.0",
     "version"       : "0.1.5",
     "perl"          : "6.c",
     "description"   : "Simple GTK 3 binding using NativeCall",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license