### PR TITLE
fix gtk_simple_use_cairo() as per issue #69

### DIFF
--- a/lib/GTK/Simple/DrawingArea.pm6
+++ b/lib/GTK/Simple/DrawingArea.pm6
@@ -14,7 +14,7 @@ my Mu $Cairo_Context;
 sub gtk_simple_use_cairo() is export {
     try {
         require Cairo;
-        $cairo_t := ::('cairo_t');
+        $cairo_t := ::('Cairo')::('cairo_t');
         $Cairo_Context := ::('Cairo')::('Context');
     }
 }


### PR DESCRIPTION
To get the following to work (display aqua square)

use v6.c;
use GTK::Simple;
use GTK::Simple::DrawingArea;

my $app = GTK::Simple::App.new(:title<Test>);
my $da = GTK::Simple::DrawingArea.new;
gtk_simple_use_cairo;

$app.set-content( $da );
$app.border-width = 20;
$da.size-request(300,300);

sub rect-do( $d, $ctx ) {
    given $ctx {
	.rgb(0, 0.7, 0.9);
	.rectangle(10, 10, 50, 50);
	.fill :preserve; .rgb(1, 1, 1);
	.stroke
    };
}

my $ctx = $da.add-draw-handler( &rect-do );
$app.run;