### PR TITLE
Add missing property and constructor params to (V|H)Box

### DIFF
--- a/lib/GTK/Simple/Box.pm6
+++ b/lib/GTK/Simple/Box.pm6
@@ -8,8 +8,8 @@ use GTK::Simple::Widget;
 
 unit role GTK::Simple::Box does GTK::Simple::Container;
 
-multi method new(*@packees) {
-    my $box = self.bless();
+multi method new(*@packees, Bool :$homogeneous = False, Int :$spacing = 0) {
+    my $box = self.bless(:$homogeneous, :$spacing);
 
     for @packees {
         if $_ ~~ Hash {
@@ -45,3 +45,8 @@ method spacing
     returns Int
     is gtk-property(&gtk_box_get_spacing, &gtk_box_set_spacing)
     { * }
+
+method homogeneous
+	returns Bool
+	is gtk-property(&gtk_box_get_homogeneous, &gtk_box_set_homogeneous)
+	{ * }

--- a/lib/GTK/Simple/HBox.pm6
+++ b/lib/GTK/Simple/HBox.pm6
@@ -9,6 +9,6 @@ unit class GTK::Simple::HBox
     does GTK::Simple::Widget
     does GTK::Simple::Box;
 
-submethod BUILD() {
-    $!gtk_widget = gtk_hbox_new(0, 0);
+submethod BUILD(Bool :$homogeneous, Int :$spacing) {
+    $!gtk_widget = gtk_hbox_new($homogeneous, $spacing);
 }

--- a/lib/GTK/Simple/Raw.pm6
+++ b/lib/GTK/Simple/Raw.pm6
@@ -235,6 +235,17 @@ sub gtk_box_set_spacing(GtkWidget $box, int32 $spacing)
     is export(:box)
     {*}
 
+sub gtk_box_get_homogeneous(GtkWidget $box)
+	returns Bool
+	is native(&gtk-lib)
+	is export(:box)
+	{*}
+
+sub gtk_box_set_homogeneous(GtkWidget $box, Bool $homogeneous)
+	is native(&gtk-lib)
+	is export(:box)
+	{*}
+
 #
 # HBox
 #

--- a/lib/GTK/Simple/VBox.pm6
+++ b/lib/GTK/Simple/VBox.pm6
@@ -9,6 +9,6 @@ unit class GTK::Simple::VBox
     does GTK::Simple::Widget
     does GTK::Simple::Box;
 
-submethod BUILD() {
-    $!gtk_widget = gtk_vbox_new(0, 0);
+submethod BUILD(Bool :$homogeneous, Int :$spacing) {
+    $!gtk_widget = gtk_vbox_new($homogeneous, $spacing);
 }


### PR DESCRIPTION
This patch adds two named parameters to `Box.new`, namely
`homogeneous` and `spacing` that are then passed to
`gtk_hbox_new`/`gtk_vbox_new` routines.

It also adds missing `homogeneous` property to `Box` role.