### PR TITLE
#83 fix build issue on Windows that occurs on some non-English versions

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -59,17 +59,17 @@ method build($workdir) {
                 ).out.lines(:close).grep({$_.chars})[*-1].uc;
             }
             without $hash {
-				$hash = run("CertUtil.exe", "-hashfile", $path, "SHA256", :out).out
-					
-					.slurp(:close, :bin) # specifying slurp(:close: :enc("utf8-c8")) does not work for some reason
-					
-					.decode("utf8-c8")   # on some non-English versions of Windows (for example German),
-					                     # the "command xy executed" trailing line has non UTF-8 chars.
-										 # The proper way to handle this would be to either use one of
-										 # the Windows code pages or inspect what code page is used, but
-										 # since we're not doing anything with this line, we can just use utf8-c8
-					
-					.subst(" ", "", :g).lines.first(/^ <xdigit>**64 $/).uc;
+                $hash = run("CertUtil.exe", "-hashfile", $path, "SHA256", :out).out
+
+                    .slurp(:close, :bin) # specifying slurp(:close: :enc("utf8-c8")) does not work for some reason
+
+                    .decode("utf8-c8")  # on some non-English versions of Windows (for example German),
+                                        # the "command xy executed" trailing line has non UTF-8 chars.
+                                        # The proper way to handle this would be to either use one of
+                                        # the Windows code pages or inspect what code page is used, but
+                                        # since we're not doing anything with this line, we can just use utf8-c8
+
+                    .subst(" ", "", :g).lines.first(/^ <xdigit>**64 $/).uc;
             }
             $hash
         }

--- a/Build.pm
+++ b/Build.pm
@@ -59,9 +59,17 @@ method build($workdir) {
                 ).out.lines(:close).grep({$_.chars})[*-1].uc;
             }
             without $hash {
-                $hash = run("CertUtil.exe", "-hashfile", $path, "SHA256", :out)
-                    .out.slurp(:close).subst(" ", "", :g)
-                    .lines.first(/^ <xdigit>**64 $/).uc;
+				$hash = run("CertUtil.exe", "-hashfile", $path, "SHA256", :out).out
+					
+					.slurp(:close, :bin) # specifying slurp(:close: :enc("utf8-c8")) does not work for some reason
+					
+					.decode("utf8-c8")   # on some non-English versions of Windows (for example German),
+					                     # the "command xy executed" trailing line has non UTF-8 chars.
+										 # The proper way to handle this would be to either use one of
+										 # the Windows code pages or inspect what code page is used, but
+										 # since we're not doing anything with this line, we can just use utf8-c8
+					
+					.subst(" ", "", :g).lines.first(/^ <xdigit>**64 $/).uc;
             }
             $hash
         }


### PR DESCRIPTION
This fixes #83 (at least for me). The issue is that the output of `CertUtil.exe` contains internationalized text in the first and third lines (irrelevant, since we're only interested in the second line containing the hash) that is localized on some configuration and does not decode as UTF-8. The proper way to solve it would be to either use one of the Windows code pages or determine/temporarily change the code page (for example, as described here: https://superuser.com/a/685264), but decoding as "utf8-c8" is good enough, too. But it will not work on systems using multi byte code pages. Probably. Likely. But neither does the current way.

Needs `--force-test` but this is an unrelated issue.