### PR TITLE
Add attach method to GTK::Simple::Grid

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,13 +1,12 @@
 {
     "name"          : "GTK::Simple",
     "license"       : "Artistic-2.0",
-    "version"       : "0.1.14",
+    "version"       : "0.1.13",
     "perl"          : "6.c",
     "description"   : "Simple GTK 3 binding using NativeCall",
     "build-depends" : [ "LWP::Simple", "Shell::Command" ],
     "test-depends"  : [ "Test" ],
     "tags"          : [ "gui" ],
-    "auth"          : "github:finanalyst",
     "provides" : {
         "GTK::Simple::GDK"               : "lib/GTK/Simple/GDK.pm6",
         "GTK::Simple::NativeLib"         : "lib/GTK/Simple/NativeLib.pm6",
@@ -56,7 +55,7 @@
         "GTK::Simple::ScrolledWindow"    : "lib/GTK/Simple/ScrolledWindow.pm6"
     },
     "repo-type"  : "git",
-    "source-url" : "git://github.com/finanalyst/GTK-Simple.git",
+    "source-url" : "git://github.com/perl6/GTK-Simple.git",
     "resources"  : [
         "blib/lib/GTK/libatk-1.0-0.dll",
         "blib/lib/GTK/libcairo-2.dll",

--- a/META6.json
+++ b/META6.json
@@ -1,12 +1,13 @@
 {
     "name"          : "GTK::Simple",
     "license"       : "Artistic-2.0",
-    "version"       : "0.1.13",
+    "version"       : "0.1.14",
     "perl"          : "6.c",
     "description"   : "Simple GTK 3 binding using NativeCall",
     "build-depends" : [ "LWP::Simple", "Shell::Command" ],
     "test-depends"  : [ "Test" ],
     "tags"          : [ "gui" ],
+    "auth"          : "github:finanalyst",
     "provides" : {
         "GTK::Simple::GDK"               : "lib/GTK/Simple/GDK.pm6",
         "GTK::Simple::NativeLib"         : "lib/GTK/Simple/NativeLib.pm6",
@@ -55,7 +56,7 @@
         "GTK::Simple::ScrolledWindow"    : "lib/GTK/Simple/ScrolledWindow.pm6"
     },
     "repo-type"  : "git",
-    "source-url" : "git://github.com/perl6/GTK-Simple.git",
+    "source-url" : "git://github.com/finanalyst/GTK-Simple.git",
     "resources"  : [
         "blib/lib/GTK/libatk-1.0-0.dll",
         "blib/lib/GTK/libcairo-2.dll",

--- a/examples/03-grid.pl6
+++ b/examples/03-grid.pl6
@@ -11,7 +11,7 @@ my GTK::Simple::App $app .= new(title => "Grid layouts!");
     The interesting bit of this example is the grid constructor.
 
 $app.set-content(
-    GTK::Simple::Grid.new(
+    my $grid = GTK::Simple::Grid.new(
 =comment
         As you can see, you pass pairs with a coordinate and size on the left
         and the widget on the right. Once again we're free to directly define
@@ -51,5 +51,11 @@ $app.set-content(
     This allows for some pretty complex layouts to be created.
 
 $app.border-width = 20;
+
+=comment
+    Perhaps later, say in response to an action by another widget, you want to add to the grid.
+    Use the attach method and provide a list of pairs exactly as for C<new>
+
+$grid.attach( [3, 0, 1, 1] => GTK::Simple::Label.new(text => "I got added later"), );
 
 $app.run;

--- a/lib/GTK/Simple/Grid.pm6
+++ b/lib/GTK/Simple/Grid.pm6
@@ -17,6 +17,14 @@ method new(*@pieces) {
     $grid;
 }
 
+method attach(*@pieces) {
+    for @pieces -> $pair {
+        die "please provide pairs with a 4-tuple of coordinates => the widget" unless +@($pair.key) == 4;
+        gtk_grid_attach($!gtk_widget, $pair.value.WIDGET, |@($pair.key));
+        gtk_widget_show($pair.value.WIDGET);
+    }
+}
+
 submethod BUILD() {
     $!gtk_widget = gtk_grid_new();
 }


### PR DESCRIPTION
After a Grid has been created, new Widgets can be attached in the same way as for the new method