### PR TITLE
nqp::hllize only takes one argument

### DIFF
--- a/lib/GTK/Simple/Scheduler.pm6
+++ b/lib/GTK/Simple/Scheduler.pm6
@@ -30,7 +30,7 @@ method process-queue() {
     unless nqp::isnull($task) {
         if nqp::islist($task) {
             my Mu $code := nqp::shift($task);
-            $code(|nqp::hllize($task, Any));
+            $code(|nqp::hllize($task));
         }
         else {
             $task();


### PR DESCRIPTION
Should fix the fail in t/01-sanity.t.