### PR TITLE
Remove unnecessary 'spacing' arguments

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name": "GTK::Simple",
   "description": "Simple GTK 3 binding using NativeCall",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "perl": "6.d",
   "authors": [
     "Jonathan Worthington",

--- a/lib/GTK/Simple/Grid.rakumod
+++ b/lib/GTK/Simple/Grid.rakumod
@@ -29,12 +29,12 @@ submethod BUILD() {
     $!gtk_widget = gtk_grid_new();
 }
 
-method row-spacing($spacing)
+method row-spacing()
     returns int32
     is gtk-property(&gtk_grid_get_row_spacing, &gtk_grid_set_row_spacing)
     {*}
 
-method column-spacing($spacing)
+method column-spacing()
     returns int32
     is gtk-property(&gtk_grid_get_column_spacing, &gtk_grid_set_column_spacing)
     {*}


### PR DESCRIPTION
Removing the arguments allows `$grid.row-spacing = X` syntax, following the format of other `GTK::Simple` properties.