### PR TITLE
Simplified sub mappings to widget constructors

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name": "GTK::Simple",
   "description": "Simple GTK 3 binding using NativeCall",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "perl": "6.d",
   "authors": [
     "Jonathan Worthington",

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 GTK::Simple is a set of simple [GTK 3](http://www.gtk.org/) bindings using
 NativeCall. Only some GTK widgets are currently implemented. However, these are
 enough to create a reasonable interactive GUI for an idiomatic Raku program.
+
 The GTK Widgets in this distribution include the following:
 
 Widget            | Description

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ VBox, HBox        | Widget containers which enable window layout design
 
 ```raku
 use GTK::Simple;
-use GTK::Simple::App;
 
 my $app = GTK::Simple::App.new( title => "Hello GTK!" );
 
@@ -61,6 +60,32 @@ $second.clicked.tap({ $app.exit; });
 $app.run;
 ```
 
+### Using :subs option
+
+Another approach is to specify `:subs` on import. This provides subroutine aliases for the constructors
+of all of the available `GTK::Simple` widgets, converted from CamelCase to kebab-case.
+
+`GTK::Simple::MenuToolButton` becomes `menu-tool-button`, `GTK::Simple::ProgressBar` becomes `progress-bar`, etc.
+
+The above example can be equivalently written as:
+
+```raku
+use GTK::Simple :subs;
+
+my $app = app(title => "Hello GTK!");
+
+$app.set-content(
+    v-box(
+        my $button1 = button(label => "Hello World"),
+        my $button2 = button(label => "Goodbye!")
+    )
+);
+
+# ...
+```
+
+### Further examples
+
 The first four examples were written as mini tutorials to show how the
 system works:
 - [Hello world](https://github.com/finanalyst/GTK-Simple/blob/master/examples/01-hello-world.raku)
@@ -68,7 +93,7 @@ system works:
 - [A simple grid](https://github.com/finanalyst/GTK-Simple/blob/master/examples/03-grid.raku)
 - [Marked Scales](https://github.com/finanalyst/GTK-Simple/blob/master/examples/04-marked-scale.raku)
 
-For more examples, please see the [`examples/`](https://github.com/finanalyst/GTK-Simple/blob/master/examples) folder.
+For more examples, please see the [examples/](https://github.com/finanalyst/GTK-Simple/blob/master/examples) folder.
 
 ## Limitations
 

--- a/lib/GTK/Simple.rakumod
+++ b/lib/GTK/Simple.rakumod
@@ -49,6 +49,6 @@ need GTK::Simple::CheckMenuItem;
 my module EXPORT::subs {
     for GTK::Simple::.kv -> $name, $class {
         my $sub-name = '&' ~ ($name ~~ / (<:Lu><:Ll>*)* /).values.map({ .Str.lc }).join("-");
-        OUR::{ $sub-name } := -> |c { $class.new(|c) };
+        OUR::{ $sub-name } := sub (|c) { $class.new(|c) };
     }
 }

--- a/lib/GTK/Simple.rakumod
+++ b/lib/GTK/Simple.rakumod
@@ -1,6 +1,8 @@
 
 use v6;
 
+unit module GTK::Simple;
+
 need GTK::Simple::ConnectionHandler;
 need GTK::Simple::Widget;
 need GTK::Simple::Container;
@@ -42,3 +44,11 @@ need GTK::Simple::ScrolledWindow;
 need GTK::Simple::Calendar;
 need GTK::Simple::ListBox;
 need GTK::Simple::CheckMenuItem;
+
+# Exports above class constructors, ex. level-bar => GTK::Simple::LevelBar.new
+my module EXPORT::subs {
+    for GTK::Simple::.kv -> $name, $class {
+        my $sub-name = '&' ~ ($name ~~ / (<:Lu><:Ll>*)* /).values.map({ .Str.lc }).join("-");
+        OUR::{ $sub-name } := -> |c { $class.new(|c) };
+    }
+}

--- a/t/01-sanity.rakutest
+++ b/t/01-sanity.rakutest
@@ -1,16 +1,15 @@
 use v6;
 use Test;
 use GTK::Simple;
-use GTK::Simple::App;
 use GTK::Simple::Scheduler;
 
 plan *;
 
 if %*ENV<DISPLAY> or $*DISTRO.is-win {
     my $g;
-    lives-ok {$g = GTK::Simple::App.new}
-    lives-ok {GTK::Simple::Scheduler.new.cue: {$g.exit}}
-    lives-ok {$g.run}
+    lives-ok {$g = GTK::Simple::App.new}, "Can create a GTK::Simple::App object";
+    lives-ok {GTK::Simple::Scheduler.new.cue: {$g.exit}}, "Cane cue app exit via a GTK::Simple::Scheduler";
+    lives-ok {$g.run}, "Can call .run on the GTK::Simple::App object";
 }
 
 done-testing;

--- a/t/01-sanity.rakutest
+++ b/t/01-sanity.rakutest
@@ -7,9 +7,9 @@ plan *;
 
 if %*ENV<DISPLAY> or $*DISTRO.is-win {
     my $g;
-    lives-ok {$g = GTK::Simple::App.new}, "Can create a GTK::Simple::App object";
-    lives-ok {GTK::Simple::Scheduler.new.cue: {$g.exit}}, "Cane cue app exit via a GTK::Simple::Scheduler";
-    lives-ok {$g.run}, "Can call .run on the GTK::Simple::App object";
+    lives-ok {$g = GTK::Simple::App.new}
+    lives-ok {GTK::Simple::Scheduler.new.cue: {$g.exit}}
+    lives-ok {$g.run}
 }
 
 done-testing;

--- a/t/02-export-subs.rakutest
+++ b/t/02-export-subs.rakutest
@@ -5,24 +5,27 @@ plan *;
 
 use GTK::Simple :subs;
 
-# We need to create app first
-my $app;
-lives-ok { $app = app }, "There is a subroutine in scope called 'app'";
-ok $app ~~ GTK::Simple::App, "'app' returns a GTK::Simple::App object";
+if %*ENV<DISPLAY> or $*DISTRO.is-win {
+    # We need to create app first
+    my $app;
+    lives-ok { $app = app }, "There is a subroutine in scope called 'app'";
+    ok $app ~~ GTK::Simple::App, "'app' returns a GTK::Simple::App object";
 
-# Other modules are pulled into GTK::Simple namespace by now that we do not want to test
-sub skip-test($name) {
-    state $skip-set = set '&' X~ <app simple raw native-lib g-d-k common property-facade>;
-    $name (elem) $skip-set
-}
+    # Other modules are pulled into GTK::Simple namespace by now that we do not want to test
+    sub skip-test($name) {
+        state $skip-set = set '&' X~ <app simple raw native-lib g-d-k common property-facade>;
+        $name (elem) $skip-set
+    }
 
-for GTK::Simple::.kv -> $name, $class {
-    my $sub-name = '&' ~ ($name ~~ / (<:Lu><:Ll>*)* /).values.map({ .Str.lc }).join("-");
-    next if skip-test($sub-name);
+    for GTK::Simple::.kv -> $name, $class {
+        my $sub-name = '&' ~ ($name ~~ / (<:Lu><:Ll>*)* /).values.map({ .Str.lc }).join("-");
+        next if skip-test($sub-name);
 
-    my $widget;
-    lives-ok { $widget = ::{$sub-name}(:label("For Button(s)"), :uri("For LinkButton")) }, "There is a subroutine in scope called '$sub-name'";
-    ok $widget ~~ $class, "'$sub-name' returns a {$class.^name} object";
+        my $widget;
+        lives-ok { $widget = ::{$sub-name}(:label("For Button(s)"), :uri("For LinkButton")) },
+        "There is a subroutine in scope called '$sub-name'";
+        ok $widget ~~ $class, "'$sub-name' returns a { $class.^name } object";
+    }
 }
 
 done-testing;

--- a/t/02-export-subs.rakutest
+++ b/t/02-export-subs.rakutest
@@ -1,0 +1,12 @@
+use v6.d;
+use Test;
+
+plan *;
+
+use GTK::Simple :subs;
+
+my $app;
+lives-ok { $app = app }, "There is a subroutine in scope called 'app'";
+ok $app ~~ GTK::Simple::App, "'app' returns a GTK::Simple::App object";
+
+done-testing;

--- a/t/02-export-subs.rakutest
+++ b/t/02-export-subs.rakutest
@@ -5,8 +5,24 @@ plan *;
 
 use GTK::Simple :subs;
 
+# We need to create app first
 my $app;
 lives-ok { $app = app }, "There is a subroutine in scope called 'app'";
 ok $app ~~ GTK::Simple::App, "'app' returns a GTK::Simple::App object";
+
+# Other modules are pulled into GTK::Simple namespace by now that we do not want to test
+sub skip-test($name) {
+    state $skip-set = set '&' X~ <app simple raw native-lib g-d-k common property-facade>;
+    $name (elem) $skip-set
+}
+
+for GTK::Simple::.kv -> $name, $class {
+    my $sub-name = '&' ~ ($name ~~ / (<:Lu><:Ll>*)* /).values.map({ .Str.lc }).join("-");
+    next if skip-test($sub-name);
+
+    my $widget;
+    lives-ok { $widget = ::{$sub-name}(:label("For Button(s)"), :uri("For LinkButton")) }, "There is a subroutine in scope called '$sub-name'";
+    ok $widget ~~ $class, "'$sub-name' returns a {$class.^name} object";
+}
 
 done-testing;


### PR DESCRIPTION
Now when you do:

  `use GTK::Simple :subs;`

you can subsequently call the constructor of any widget via a simplified
version of it's name:

```
  my $button = button(label => "Shorter");
  my $list-box = list-box;
  my $file-chooser-button = file-chooser-button(label => "File?");
```

The pattern is a simple conversion from camel case to kebab case.
Delicious!

This also fixes the issue of needing to `use GTK::Simple::App;` on a
separate line. Now it is available immediately. This applies to both
`:subs` and regular versions.